### PR TITLE
Fix which links in top menu that should be prevented from redirecting

### DIFF
--- a/web/themes/custom/camp/js/camp.main.js
+++ b/web/themes/custom/camp/js/camp.main.js
@@ -3,7 +3,7 @@
   /**
    * Implementation of the countdown.
    */
-  Drupal.behaviors.to_menu = {
+  Drupal.behaviors.top_menu = {
     attach: function (context, settings) {
 
       // Initialize the behavior.
@@ -16,7 +16,7 @@
         // Make menu toggleable.
         $(menuElements).click(function(event) {
           // Only if not a phone.
-          if ($(window).width() > 768) {
+          if ($(window).width() > 768 && $(this).parent().index() <= 1) {
             toggleSubMenu(event, $(this));
           }
         });


### PR DESCRIPTION
It should not be all links in the top menu that shoudl have a event.preventDefault().
Therefor we on apply it on the 2 first elements

SL17-14